### PR TITLE
Make Makefile portable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: compile test deps
 
-SRC_FILES := $(basename $(shell find fnl -type f -name "*.fnl" ! -name "macros.fnl" -printf '%P\n'))
+SRC_FILES := $(basename $(shell find fnl -type f -name "*.fnl" ! -name "macros.fnl" | cut -d'/' -f2-))
 
 compile:
 	rm -rf lua


### PR DESCRIPTION
`-printf` is an non-POSIX option only available on GNU find. This commit uses `cut` instead to make possible to compile Aniseed on BSD systems like FreeBSD and macOS