### PR TITLE
Update assoc-in typo in aniseed.txt

### DIFF
--- a/doc/aniseed.txt
+++ b/doc/aniseed.txt
@@ -427,7 +427,7 @@ example.
 
   `(assoc-in t k v)`
     Set the key path `ks` in table `t` to the value `v` while safely handling `nil`.
-    `(assoc-in {:foo {:bar 10}} [:foo :bar] 15) // => {:foo {:bar 11}}`
+    `(assoc-in {:foo {:bar 10}} [:foo :bar] 15) // => {:foo {:bar 15}}`
 
   `(update t k f)`
     Replace the key `k` in table `t` by passing the current value through the


### PR DESCRIPTION
I've been having a look at Lua scripting in nvim and also investigating Fennel/Conjure which seem very cool.

I noticed what looked to be a small error in the example provided with `assoc-in` in the aniseed.core docs. This commit fixes up the example.

To check before opening this, I tested the example in a local conjure environment. From the log:

```
; --------------------------------------------------------------------------------
; eval (root-form): (a.assoc-in {:foo {:bar 10}} [:foo :bar] 15)
{
  :foo {
    :bar 15
  }
}
```