### PR TITLE
enhance: makefile, run test in nvim headless

### DIFF
--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -3,7 +3,7 @@
 # Compiles all Fennel code into Lua assuming you have Aniseed cloned through dep.sh.
 # Usage: deps/aniseed/scripts/compile.sh
 
-nvim -u NONE \
+nvim --headless -u NONE \
     -c "let &runtimepath = &runtimepath . ',deps/aniseed,' . getcwd()" \
     -c "lua require('aniseed.compile').glob('**/*.fnl', 'fnl', 'lua')" \
     +q

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -6,7 +6,7 @@
 # Environment (optional): PREFIX (first-ish arg to nvim), SUFFIX (last arg to nvim)
 # Usage: PREFIX="-c 'syntax on'" SUFFIX="foo.clj" deps/aniseed/scripts/test.sh
 
-nvim -u NONE \
+nvim --headless -u NONE \
     $PREFIX \
     -c "let &runtimepath = &runtimepath . ',' . getcwd()" \
     -c "let &runtimepath = &runtimepath . ',' . getcwd() . '/test'" \
@@ -16,6 +16,5 @@ nvim -u NONE \
     $SUFFIX
 
 EXIT_CODE=$?
-cat test/results.txt
 echo
 exit $EXIT_CODE

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -16,5 +16,7 @@ nvim --headless -u NONE \
     $SUFFIX
 
 EXIT_CODE=$?
+rm test/results.txt
+rm -rf test/lua 
 echo
 exit $EXIT_CODE

--- a/seed/Makefile
+++ b/seed/Makefile
@@ -1,6 +1,6 @@
+.SILENT: test complile
 .PHONY: deps compile test
-
-default: deps compile test
+default: compile test
 
 deps:
 	scripts/dep.sh Olical aniseed origin/master


### PR DESCRIPTION
- Fixes duplication of tests resutls when running tests
- run headless nvim to bypass this annoying screen refresh 
- add `MAKEFLAGS += --silent` to silent deleting and removing of files
- remove deps from make default 

Other: 
- find out how to make deps not silent to see progress messages.
- the following part is useless I think when running compile.sh. maybe just the last part 
```
sending incremental file list
created directory lua/libtam/aniseed
./
compile.lua
core.lua
dotfiles.lua
env.lua
eval.lua
fennel.lua
fs.lua
macros.fnl
nvim.lua
string.lua
test.lua
view.lua
deps/
deps/fennel.lua
deps/fennelview.lua
deps/nvim.lua
nvim/
nvim/util.lua
```