### PR TITLE
Check plugin name in seed.sh

### DIFF
--- a/scripts/seed.sh
+++ b/scripts/seed.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # Sets up a new Aniseed plugin project within the current directory.
 # Warning: Only run in new empty directories, it will replace your

--- a/scripts/seed.sh
+++ b/scripts/seed.sh
@@ -6,6 +6,13 @@
 # Warning: Requires `make` as part of the workflow.
 # Usage: curl -fL https://raw.githubusercontent.com/Olical/aniseed/master/scripts/seed.sh | sh
 
+plug_name=${PWD##*/}
+if [[ $plug_name == *"."* ]]
+then
+    printf "ERROR: Invalid plugin name '$plug_name'. Dots (.) are not allowed.\n"
+    exit 1
+fi
+
 mkdir -p scripts
 
 printf "$(tput bold)Downloading Aniseed dependency manager script...\n\n"
@@ -18,7 +25,6 @@ scripts/dep.sh Olical aniseed origin/master 2>/dev/null;
 printf "Creating your new plugin...\n\n"
 cp -r deps/aniseed/seed/* .
 cp deps/aniseed/seed/.gitignore .
-plug_name=${PWD##*/}
 mv ./fnl/example ./fnl/$plug_name
 mv ./test/fnl/example ./test/fnl/$plug_name
 mv ./plugin/example.vim ./plugin/$plug_name.vim


### PR DESCRIPTION
Fail early when there are dots in the name of plugins when creating new plugins (with seed.sh).

Now you get the following error when a new plugin contains a `.`:
```
stefan@faultier:/t/foo.bar
➤ pwd
/tmp/foo.bar
stefan@faultier:/t/foo.bar
➤ ~/coding/aniseed/scripts/seed.sh
ERROR: Invalid plugin name 'foo.bar'. Dots (.) are not allowed.
stefan@faultier:/t/foo.bar
```

I also switched `seed.sh` from sh to bash, not sure if you used sh on purpose. All other scripts use bash.