### PR TITLE
Fix boot up when setting aniseed#env as a dictionary

### DIFF
--- a/plugin/aniseed.vim
+++ b/plugin/aniseed.vim
@@ -2,5 +2,10 @@ set lispwords+=module
 
 if exists("g:aniseed#env")
   let s:opts = get(g:, "aniseed#env")
-  call luaeval("require('aniseed.env').init(_A)", s:opts == v:true ? {} : s:opts)
+
+  if type(s:opts) == 6 && s:opts == v:true
+    s:opts = {}
+  endif
+
+  call luaeval("require('aniseed.env').init(_A)", s:opts)
 end


### PR DESCRIPTION
The docs state that you can set this variable either `v:true`
or an options dictionary, but by setting it to a dictionary, an
exception would be raised saying 'Can only compare dictionary with a
dictionary'.
