### PR TITLE
Implement aniseed.core/str akin to Clojure str

### DIFF
--- a/fnl/aniseed/core.fnl
+++ b/fnl/aniseed/core.fnl
@@ -175,6 +175,18 @@
       "nil"
       s)))
 
+(defn str [...]
+  (->> [...]
+       (map
+         (fn [s]
+           (if (string? s)
+             s
+             (pr-str s))))
+       (reduce
+         (fn [acc s]
+           (.. acc s))
+         "")))
+
 (defn println [...]
   (->> [...]
        (map

--- a/test/fnl/aniseed/core-test.fnl
+++ b/test/fnl/aniseed/core-test.fnl
@@ -92,6 +92,15 @@
   (t.pr= "1 2 3" (a.pr-str 1 2 3))
   (t.pr= "nil" (a.pr-str nil)))
 
+(deftest str
+  (t.pr= "" (a.str))
+  (t.pr= "" (a.str ""))
+  (t.pr= "" (a.str nil))
+  (t.pr= "abc" (a.str "abc"))
+  (t.pr= "abc" (a.str "a" "b" "c"))
+  (t.pr= "{:a \"abc\"}" (a.str {:a :abc}))
+  (t.pr= "[1 2 3]abc" (a.str [1 2 3] "a" "bc")))
+
 (deftest map
   (t.pr= [2 3 4] (a.map a.inc [1 2 3])))
 


### PR DESCRIPTION
This implementation borrows entirely from the existing
aniseed.core/println function, differing only in that (1) it does not
put spaces into the final string between its arguments and (2) it
returns the string rather than printing it.

I recognize that a str function is already provided in a different
module. I believe the presence of this aniseed.core/str function will
not cause confusion and will ease the learning curve for Clojure
developers coming to Fennel/Lua, who may not be familiar with Lua's
string concatenation syntax exposed by Fennel and who might be surprised
by certain data types causing errors when passed to .. rather than
providing default string representations.

----

Further thoughts:

* I appreciate your open source contributions and your time in reading this PR.
* I'm happy to include the compiled `lua/aniseed/core.lua` if desired, I wasn't sure if anything environment-specific on my end might cause issues with the output Lua code (I was made further suspicious by `lua/aniseed/deps/fennel.lua` seeing changes as part of my work).
* I'm happy to add/remove/change the tests for this function, I recognize there are many cases one could cover.