### PR TITLE
Expand configured input and output paths

### DIFF
--- a/doc/aniseed.txt
+++ b/doc/aniseed.txt
@@ -530,8 +530,8 @@ example.
     See |aniseed-env| for more information. `opts` is an optional table that
     can contain the following:
       `module` - name of the module to load on init, defaults to `"init"`.
-      `input` - dir under config for input, defaults to `"/fnl"`.
-      `output` - dir under config for compiled output, defaults to `"/lua"`.
+      `input` - dir for input, defaults to `"/fnl"` under config.
+      `output` - dir for compiled output, defaults to `"/lua"` under config.
     You should set the `g:aniseed#env` variable to `v:true` or your desired
     configuration table rather than calling this directly for optimal
     behaviour.

--- a/fnl/aniseed/env.fnl
+++ b/fnl/aniseed/env.fnl
@@ -17,9 +17,9 @@
   (let [opts (if (= :table (type opts))
                opts
                {})
-        glob-expr "**/*.fnl" 
-        fnl-dir (or opts.input (.. config-dir fs.path-sep "fnl"))
-        lua-dir (or opts.output (.. config-dir fs.path-sep "lua"))]
+        glob-expr "**/*.fnl"
+        fnl-dir (nvim.fn.expand (or opts.input (.. config-dir fs.path-sep "fnl")))
+        lua-dir (nvim.fn.expand (or opts.output (.. config-dir fs.path-sep "lua")))]
 
     ;; Support requiring Lua modules from non-standard output directories.
     (set package.path (.. package.path ";" lua-dir fs.path-sep "?.lua"))

--- a/lua/aniseed/env.lua
+++ b/lua/aniseed/env.lua
@@ -81,8 +81,8 @@ do
         opts0 = {}
       end
       local glob_expr = "**/*.fnl"
-      local fnl_dir = (opts0.input or (config_dir .. fs["path-sep"] .. "fnl"))
-      local lua_dir = (opts0.output or (config_dir .. fs["path-sep"] .. "lua"))
+      local fnl_dir = nvim.fn.expand((opts0.input or (config_dir .. fs["path-sep"] .. "fnl")))
+      local lua_dir = nvim.fn.expand((opts0.output or (config_dir .. fs["path-sep"] .. "lua")))
       package.path = (package.path .. ";" .. lua_dir .. fs["path-sep"] .. "?.lua")
       local function _4_(path)
         if fs["macro-file-path?"](path) then


### PR DESCRIPTION
Hi! Thanks for Aniseed! (And Conjure!)

I've recently started doing a little Neovim configuration in Fennel, but because I'm an oddball, I wanted to keep it under `~/.vim` with the rest of my vim stuff.

While trying to make that work, I realized that the docs didn't quite match what's happening in the code. The `input` and `output` arguments were treated as full paths if given, but never expanded.

This PR tweaks the docs to reflect that, and it also runs the paths through vim's path expander to handle stuff like `~`.