### PR TITLE
Add syntax highlight for nil-safe table lookup

### DIFF
--- a/syntax/fennel.vim
+++ b/syntax/fennel.vim
@@ -38,6 +38,7 @@ syn keyword FennelSpecialForm ->>
 syn keyword FennelSpecialForm -?>
 syn keyword FennelSpecialForm -?>>
 syn keyword FennelSpecialForm .
+syn keyword FennelSpecialForm ?.
 syn keyword FennelSpecialForm ..
 syn keyword FennelSpecialForm /
 syn keyword FennelSpecialForm //


### PR DESCRIPTION
Adds highlighting for `?.`
Reference 
https://fennel-lang.org/reference#nil-safe-.-table-lookup