### PR TITLE
Fix module return value

### DIFF
--- a/fnl/aniseed/compile.fnl
+++ b/fnl/aniseed/compile.fnl
@@ -15,7 +15,8 @@
           (.. "\"" (string.gsub filename "\\" "\\\\") "\"")
           "nil")
         ")"
-        "(require-macros \"" macros-module "\")\n" (or code ""))))
+        "(require-macros \"" macros-module "\")\n"
+        "(wrap-module-body " (or code "") ")")))
 
 ;; Magic strings from the macros that allow us to emit clean code.
 (def marker-prefix "ANISEED_")

--- a/fnl/aniseed/macros.fnl
+++ b/fnl/aniseed/macros.fnl
@@ -193,11 +193,35 @@
      (print (.. "Elapsed time: " (/ (- end# start#) 1000000) " msecs"))
      result#))
 
+;; Checks surrounding scope for *module* and, if found, makes sure *module* is
+;; inserted after `last-expr` (and therefore *module* is returned)
 (fn wrap-last-expr [last-expr]
   (if (rawget (. (get-scope) :symmeta) :*module*)
       `(do ,last-expr ,(sym :*module*))
       last-expr))
 
+;; Used by aniseed.compile to wrap the entire body of a file, replacing the
+;; last expression with another wrapper; `wrap-last-expr` which handles the
+;; module's return value.
+;;
+;; i.e.
+;; (wrap-module-body
+;; (module foo)
+;; (def x 1)
+;; (vim.cmd "...")) ; vim.cmd returns a string which becomes the returned value
+;;                  ; for the entire file once compiled
+;; --> expands to:
+;; (do
+;;   (module foo)
+;;   (def x 1)
+;;   (wrap-last-expr (vim.cmd "...")))
+;; --> expands to:
+;; (do
+;;   (module foo)
+;;   (def x 1)
+;;   (do
+;;     (vim.cmd "...")
+;;     *module*))
 (fn wrap-module-body [...]
   (let [body# [...]
         last-expr# (table.remove body#)]

--- a/fnl/aniseed/macros.fnl
+++ b/fnl/aniseed/macros.fnl
@@ -193,18 +193,22 @@
      (print (.. "Elapsed time: " (/ (- end# start#) 1000000) " msecs"))
      result#))
 
+(fn wrap-last-expr [last-expr]
+  (if (rawget (. (get-scope) :symmeta) :*module*)
+      `(do ,last-expr ,(sym :*module*))
+      last-expr))
+
 (fn wrap-module-body [...]
-   (let [body# [...]
-         last-expr# (table.remove body#)]
-     (table.insert body#
-                   `(let [original-return# (do ,last-expr#)]
-                      (or ,(sym :*module*) original-return#)))
-     `(do ,(unpack body#))))
+  (let [body# [...]
+        last-expr# (table.remove body#)]
+    (table.insert body# `(wrap-last-expr ,last-expr#))
+    `(do ,(unpack body#))))
 
 {:module module
  :def- def- :def def
  :defn- defn- :defn defn
  :defonce- defonce- :defonce defonce
+ :wrap-last-expr wrap-last-expr
  :wrap-module-body wrap-module-body
  :deftest deftest
  :time time}

--- a/fnl/aniseed/macros.fnl
+++ b/fnl/aniseed/macros.fnl
@@ -193,9 +193,18 @@
      (print (.. "Elapsed time: " (/ (- end# start#) 1000000) " msecs"))
      result#))
 
+(fn wrap-module-body [...]
+   (let [body# [...]
+         last-expr# (table.remove body#)]
+     (table.insert body#
+                   `(let [original-return# (do ,last-expr#)]
+                      (or ,(sym "*module*") original-return#)))
+     `(do ,(unpack body#))))
+
 {:module module
  :def- def- :def def
  :defn- defn- :defn defn
  :defonce- defonce- :defonce defonce
+ :wrap-module-body wrap-module-body
  :deftest deftest
  :time time}

--- a/fnl/aniseed/macros.fnl
+++ b/fnl/aniseed/macros.fnl
@@ -198,7 +198,7 @@
          last-expr# (table.remove body#)]
      (table.insert body#
                    `(let [original-return# (do ,last-expr#)]
-                      (or ,(sym "*module*") original-return#)))
+                      (or ,(in-scope? (sym "*module*")) original-return#)))
      `(do ,(unpack body#))))
 
 {:module module

--- a/fnl/aniseed/macros.fnl
+++ b/fnl/aniseed/macros.fnl
@@ -198,7 +198,7 @@
          last-expr# (table.remove body#)]
      (table.insert body#
                    `(let [original-return# (do ,last-expr#)]
-                      (or ,(in-scope? (sym "*module*")) original-return#)))
+                      (or ,(sym :*module*) original-return#)))
      `(do ,(unpack body#))))
 
 {:module module

--- a/lua/aniseed/compile.lua
+++ b/lua/aniseed/compile.lua
@@ -34,7 +34,7 @@ local function macros_prefix(code, opts)
       return "nil"
     end
   end
-  return ("(local *file* " .. _3_() .. ")" .. "(require-macros \"" .. macros_module .. "\")\n" .. (code or ""))
+  return ("(local *file* " .. _3_() .. ")" .. "(require-macros \"" .. macros_module .. "\")\n" .. "(wrap-module-body " .. (code or "") .. ")")
 end
 _2amodule_2a["macros-prefix"] = macros_prefix
 local marker_prefix = "ANISEED_"

--- a/lua/aniseed/deps/fennel.lua
+++ b/lua/aniseed/deps/fennel.lua
@@ -363,9 +363,9 @@ package.preload["aniseed.fennel.repl"] = package.preload["aniseed.fennel.repl"] 
           _571_ = _572_
         end
       end
-      if ((_G.type(_571_) == "table") and ((_571_).what == "Lua") and (nil ~= (_571_).linedefined) and (nil ~= (_571_).source) and (nil ~= (_571_).short_src)) then
-        local line = (_571_).linedefined
+      if ((_G.type(_571_) == "table") and (nil ~= (_571_).source) and (nil ~= (_571_).linedefined) and ((_571_).what == "Lua") and (nil ~= (_571_).short_src)) then
         local source = (_571_).source
+        local line = (_571_).linedefined
         local src = (_571_).short_src
         local fnlsrc
         do

--- a/lua/aniseed/macros.fnl
+++ b/lua/aniseed/macros.fnl
@@ -193,11 +193,35 @@
      (print (.. "Elapsed time: " (/ (- end# start#) 1000000) " msecs"))
      result#))
 
+;; Checks surrounding scope for *module* and, if found, makes sure *module* is
+;; inserted after `last-expr` (and therefore *module* is returned)
 (fn wrap-last-expr [last-expr]
   (if (rawget (. (get-scope) :symmeta) :*module*)
       `(do ,last-expr ,(sym :*module*))
       last-expr))
 
+;; Used by aniseed.compile to wrap the entire body of a file, replacing the
+;; last expression with another wrapper; `wrap-last-expr` which handles the
+;; module's return value.
+;;
+;; i.e.
+;; (wrap-module-body
+;; (module foo)
+;; (def x 1)
+;; (vim.cmd "...")) ; vim.cmd returns a string which becomes the returned value
+;;                  ; for the entire file once compiled
+;; --> expands to:
+;; (do
+;;   (module foo)
+;;   (def x 1)
+;;   (wrap-last-expr (vim.cmd "...")))
+;; --> expands to:
+;; (do
+;;   (module foo)
+;;   (def x 1)
+;;   (do
+;;     (vim.cmd "...")
+;;     *module*))
 (fn wrap-module-body [...]
   (let [body# [...]
         last-expr# (table.remove body#)]

--- a/lua/aniseed/macros.fnl
+++ b/lua/aniseed/macros.fnl
@@ -193,18 +193,22 @@
      (print (.. "Elapsed time: " (/ (- end# start#) 1000000) " msecs"))
      result#))
 
+(fn wrap-last-expr [last-expr]
+  (if (rawget (. (get-scope) :symmeta) :*module*)
+      `(do ,last-expr ,(sym :*module*))
+      last-expr))
+
 (fn wrap-module-body [...]
-   (let [body# [...]
-         last-expr# (table.remove body#)]
-     (table.insert body#
-                   `(let [original-return# (do ,last-expr#)]
-                      (or ,(sym :*module*) original-return#)))
-     `(do ,(unpack body#))))
+  (let [body# [...]
+        last-expr# (table.remove body#)]
+    (table.insert body# `(wrap-last-expr ,last-expr#))
+    `(do ,(unpack body#))))
 
 {:module module
  :def- def- :def def
  :defn- defn- :defn defn
  :defonce- defonce- :defonce defonce
+ :wrap-last-expr wrap-last-expr
  :wrap-module-body wrap-module-body
  :deftest deftest
  :time time}

--- a/lua/aniseed/macros.fnl
+++ b/lua/aniseed/macros.fnl
@@ -193,9 +193,18 @@
      (print (.. "Elapsed time: " (/ (- end# start#) 1000000) " msecs"))
      result#))
 
+(fn wrap-module-body [...]
+   (let [body# [...]
+         last-expr# (table.remove body#)]
+     (table.insert body#
+                   `(let [original-return# (do ,last-expr#)]
+                      (or ,(sym "*module*") original-return#)))
+     `(do ,(unpack body#))))
+
 {:module module
  :def- def- :def def
  :defn- defn- :defn defn
  :defonce- defonce- :defonce defonce
+ :wrap-module-body wrap-module-body
  :deftest deftest
  :time time}

--- a/lua/aniseed/macros.fnl
+++ b/lua/aniseed/macros.fnl
@@ -198,7 +198,7 @@
          last-expr# (table.remove body#)]
      (table.insert body#
                    `(let [original-return# (do ,last-expr#)]
-                      (or ,(sym "*module*") original-return#)))
+                      (or ,(in-scope? (sym "*module*")) original-return#)))
      `(do ,(unpack body#))))
 
 {:module module

--- a/lua/aniseed/macros.fnl
+++ b/lua/aniseed/macros.fnl
@@ -198,7 +198,7 @@
          last-expr# (table.remove body#)]
      (table.insert body#
                    `(let [original-return# (do ,last-expr#)]
-                      (or ,(in-scope? (sym "*module*")) original-return#)))
+                      (or ,(sym :*module*) original-return#)))
      `(do ,(unpack body#))))
 
 {:module module


### PR DESCRIPTION
Continuation of #90

- added `wrap-module-body` macro
- changed `compile.macros-prefix` to wrap body in `wrap-module-body`. That should probably be moved to its own function(?) or the name of `macros-prefix` should be changed
- recompiled with these changes

This appears to generate the right lua for my dotfiles. It looks like parinfer changed the files more than necessary so I'll have to fix that tomorrow.

See:
https://github.com/harrygallagher4/nvim/blob/95ba7461baf53393bc4f6861d19565b1a940a098/fnl/dotfiles/init.fnl (module that has a return value other than `*module*`, now with `*module*` removed) 
https://gist.github.com/harrygallagher4/847440c11921153d8f4fc6871bb49820#file-init-lua-L34-L38 (compiled lua)
https://github.com/harrygallagher4/nvim/blob/2cf6ff701aacb8a5cdf734216c2944c4f3f99804/fnl/dotfiles/test.fnl (non-aniseed module)
https://gist.github.com/harrygallagher4/847440c11921153d8f4fc6871bb49820#file-test-lua (compiled)