### PR TITLE
One last change to module return macros

### DIFF
--- a/fnl/aniseed/macros.fnl
+++ b/fnl/aniseed/macros.fnl
@@ -196,8 +196,8 @@
 ;; Checks surrounding scope for *module* and, if found, makes sure *module* is
 ;; inserted after `last-expr` (and therefore *module* is returned)
 (fn wrap-last-expr [last-expr]
-  (if (rawget (. (get-scope) :symmeta) :*module*)
-      `(do ,last-expr ,(sym :*module*))
+  (if (in-scope? mod-sym)
+      `(do ,last-expr ,mod-sym)
       last-expr))
 
 ;; Used by aniseed.compile to wrap the entire body of a file, replacing the

--- a/lua/aniseed/macros.fnl
+++ b/lua/aniseed/macros.fnl
@@ -196,8 +196,8 @@
 ;; Checks surrounding scope for *module* and, if found, makes sure *module* is
 ;; inserted after `last-expr` (and therefore *module* is returned)
 (fn wrap-last-expr [last-expr]
-  (if (rawget (. (get-scope) :symmeta) :*module*)
-      `(do ,last-expr ,(sym :*module*))
+  (if (in-scope? mod-sym)
+      `(do ,last-expr ,mod-sym)
       last-expr))
 
 ;; Used by aniseed.compile to wrap the entire body of a file, replacing the


### PR DESCRIPTION
My commit message sums it up well. `in-scope?` basically does the same thing as my hacky `(rawget (get-scope) ...)` test but I think I trust the Fennel devs more than myself to do scope checking.

commitmsg:
```
just realized the double-wrapping of the last expression fixes the
earlier issues I ran into with get-scope.
- also replace (sym :*module*) with just mod-sym
```