### PR TITLE
be less verbose about wrap-last-expr (fixes #95)

### DIFF
--- a/doc/aniseed.txt
+++ b/doc/aniseed.txt
@@ -343,13 +343,13 @@ them in any other forms.
   time, just as a quick and easy to use tool during development.
 
 `(wrap-last-expr last-expr)`
-  Checks surrounding scope for *module* and, if found, makes sure *module* is
-  inserted after `last-expr` (and therefore *module* is returned)
+  Used by `aniseed.compile` to ensure the current module is returned if
+  necessary.
 
 `(wrap-module-body ...)`
   Used by `aniseed.compile` to wrap the entire body of a file, replacing the
-  last expression with another wrapper; `wrap-last-expr` which handles the
-  module's return value.
+  last expression with `wrap-last-expr` which handles the module's return
+  value.
 
 ==============================================================================
 FUNCTIONS                                                  *aniseed-functions*


### PR DESCRIPTION
This should fix the duplicate tag issue, and I think it's probably better to be brief here since `wrap-last-expr` shouldn't be used except in the compiler.