### PR TITLE
Add when-let as a core macro

### DIFF
--- a/fnl/aniseed/macros.fnl
+++ b/fnl/aniseed/macros.fnl
@@ -244,10 +244,23 @@
     (table.insert body# `(wrap-last-expr ,last-expr#))
     `(do ,(unpack body#))))
 
+(fn when-let [bindings ...]
+  ; (assert-compile (sequence? bindings) (.. "expected sequence for bindings, got " (type bindings)))
+  (assert-compile (= 0 (% (length bindings) 2)) "expected even number of bindings")
+  (if (< 0 (length bindings))
+    (let [[f t & r] bindings]
+      `(let [result# ,t]
+         (when result#
+           (let [,f result#]
+             (when-let ,r
+               ,...)))))
+    `(do ,...)))
+
 {:module module
  :def- def- :def def
  :defn- defn- :defn defn
  :defonce- defonce- :defonce defonce
+ :when-let when-let
  :wrap-last-expr wrap-last-expr
  :wrap-module-body wrap-module-body
  :deftest deftest

--- a/lua/aniseed/macros.fnl
+++ b/lua/aniseed/macros.fnl
@@ -244,10 +244,23 @@
     (table.insert body# `(wrap-last-expr ,last-expr#))
     `(do ,(unpack body#))))
 
+(fn when-let [bindings ...]
+  ; (assert-compile (sequence? bindings) (.. "expected sequence for bindings, got " (type bindings)))
+  (assert-compile (= 0 (% (length bindings) 2)) "expected even number of bindings")
+  (if (< 0 (length bindings))
+    (let [[f t & r] bindings]
+      `(let [result# ,t]
+         (when result#
+           (let [,f result#]
+             (when-let ,r
+               ,...)))))
+    `(do ,...)))
+
 {:module module
  :def- def- :def def
  :defn- defn- :defn defn
  :defonce- defonce- :defonce defonce
+ :when-let when-let
  :wrap-last-expr wrap-last-expr
  :wrap-module-body wrap-module-body
  :deftest deftest

--- a/test/fnl/aniseed/macros-test.fnl
+++ b/test/fnl/aniseed/macros-test.fnl
@@ -15,3 +15,28 @@
   (t.= 1 calls)
 
   (t.= :destructure-require (identity :destructure-require)))
+
+(deftest when-let
+  (t.= :empty
+       (when-let []
+         :empty))
+  (t.= :ok
+       (when-let [foo :ok]
+         foo))
+  (t.= nil
+       (when-let [foo false]
+         :first))
+  (t.= :second
+       (when-let [foo true
+                  bar :second]
+         bar))
+  (t.= nil
+       (when-let [foo true
+                  bar nil
+                  qux :third]
+         bar))
+  (t.pr= [:first :second :third]
+         (when-let [foo :first
+                    bar :second
+                    qux :third]
+           [foo bar qux])))


### PR DESCRIPTION
I noticed a lot of `(let [...] (when ...` in conjure, so it seemed like a good idea to add this trusty helper macro to Aniseed!

I originally had it as single-pair Clojure version but given fennel's `if` being variadic, seemed appropriate to make this one variadic as well. I originally had an assertion that the bindings is `sequential?` as seen in the comment, but I couldn't figure out how to make fennel see that recursive calls were passing in sequences and not tables. `icollect` didn't help, and neither did `[(unpack r)]`, so I'm not sure what it would take.